### PR TITLE
bug fix: update schema to reflect recent migration

### DIFF
--- a/db/migrations/0004_restore_auth_account_columns.sql
+++ b/db/migrations/0004_restore_auth_account_columns.sql
@@ -1,0 +1,12 @@
+-- Migration: 0004_restore_auth_account_columns
+-- Description: Restore refresh_token and session_state columns to the accounts table.
+--
+-- These columns were dropped in migration 0001_parched_texas_twister.sql under the
+-- assumption that they were unused. However, @auth/drizzle-adapter's
+-- DefaultPostgresAccountsTable type requires them to be present in the schema —
+-- omitting either column causes a TypeScript compile error. The columns remain
+-- nullable: Google OAuth does not populate refresh_token (unless offline access is
+-- requested) and does not use session_state (an OpenID Connect-only field).
+
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS refresh_token  TEXT;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS session_state  TEXT;

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -15,15 +15,19 @@ import {
 export const users = pgTable('users', {
   id:            uuid('id').primaryKey().defaultRandom(),
   createdAt:     timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-  // NextAuth Drizzle adapter required fields
+  // Required by @auth/drizzle-adapter (DefaultPostgresUsersTable)
   name:          text('name'),
   email:         text('email').unique(),
   emailVerified: timestamp('email_verified', { mode: 'date' }),
   image:         text('image'),
+  // App-specific
   isAdmin:       boolean('is_admin').notNull().default(false),
 })
 
 // ── NextAuth accounts ──────────────────────────────────────────────────────────
+// All columns below are required by @auth/drizzle-adapter (DefaultPostgresAccountsTable).
+// The type definition is strict — omitting any column causes a compile error, even if
+// the provider (Google OAuth) does not populate it at runtime.
 export const accounts = pgTable(
   'accounts',
   {
@@ -31,11 +35,13 @@ export const accounts = pgTable(
     type:              text('type').notNull(),
     provider:          text('provider').notNull(),
     providerAccountId: text('provider_account_id').notNull(),
+    refresh_token:     text('refresh_token'),     // not sent by Google OAuth; required by adapter type
     access_token:      text('access_token'),
     expires_at:        integer('expires_at'),
     token_type:        text('token_type'),
     scope:             text('scope'),
     id_token:          text('id_token'),
+    session_state:     text('session_state'),     // OpenID Connect only; required by adapter type
   },
   (t) => [
     primaryKey({ columns: [t.provider, t.providerAccountId] }),


### PR DESCRIPTION
was running into a login server error on redirect that was happening because the server was running into a 500

this was because the schema was not up to date with a recent migration that dropped two unused columns