### PR TITLE
chore: code cleanup

### DIFF
--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -7,8 +7,6 @@ import CssBaseline from '@mui/material/CssBaseline'
 import { makeTheme, type ThemeMode } from './theme'
 import { gqlFetch } from '@/lib/graphql/client'
 
-// ── ThemeContext ───────────────────────────────────────────────────────────────
-
 interface ThemeContextValue {
   mode: ThemeMode
   setMode: (mode: ThemeMode) => void
@@ -32,8 +30,6 @@ const UPDATE_SETTINGS_MUTATION = `
 const SETTINGS_QUERY = `
   query { settings { preferences } }
 `
-
-// ── Providers ─────────────────────────────────────────────────────────────────
 
 function setCookie(m: ThemeMode) {
   document.cookie = `theme=${m}; path=/; max-age=31536000; SameSite=Lax`

--- a/src/app/components/dashboard/CorrectiveActionsCard.tsx
+++ b/src/app/components/dashboard/CorrectiveActionsCard.tsx
@@ -8,16 +8,13 @@ import TableHead from '@mui/material/TableHead'
 import TableRow from '@mui/material/TableRow'
 import Typography from '@mui/material/Typography'
 import DashboardCard from './DashboardCard'
+import { isOverdue } from '@/lib/dateUtils'
 import type { OpenCorrectiveAction } from './types'
 
 interface Props {
   actions: OpenCorrectiveAction[]
   onSelectSubmission: (submissionId: string) => void
   loading?: boolean
-}
-
-function isOverdue(dueDate: string) {
-  return dueDate && new Date(dueDate) < new Date()
 }
 
 export default function CorrectiveActionsCard({
@@ -49,15 +46,9 @@ export default function CorrectiveActionsCard({
           <Table size="small" stickyHeader>
             <TableHead>
               <TableRow>
-                <TableCell sx={{ fontWeight: 600, fontSize: '0.75rem' }}>
-                  Facility
-                </TableCell>
-                <TableCell sx={{ fontWeight: 600, fontSize: '0.75rem' }}>
-                  Action
-                </TableCell>
-                <TableCell sx={{ fontWeight: 600, fontSize: '0.75rem' }}>
-                  Due
-                </TableCell>
+                <TableCell>Facility</TableCell>
+                <TableCell>Action</TableCell>
+                <TableCell>Due</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>

--- a/src/app/components/dashboard/DashboardFilterBar.tsx
+++ b/src/app/components/dashboard/DashboardFilterBar.tsx
@@ -151,7 +151,6 @@ export default function DashboardFilterBar({
                 fontSize: '0.72rem',
                 py: 0.25,
                 px: 1.25,
-                textTransform: 'none',
                 whiteSpace: 'nowrap',
               }}
             >

--- a/src/app/components/dashboard/DashboardFilterBar.tsx
+++ b/src/app/components/dashboard/DashboardFilterBar.tsx
@@ -37,7 +37,6 @@ interface Props {
   selectedSubmissionId: string
   onSubmissionChange: (id: string) => void
   history: HistoryItem[]
-  historyLoading?: boolean
   onItemTeamsChanged?: (
     itemId: string,
     teams: Array<{ id: string; name: string }>,

--- a/src/app/components/dashboard/DashboardPanel.tsx
+++ b/src/app/components/dashboard/DashboardPanel.tsx
@@ -78,7 +78,6 @@ export default function DashboardPanel({
         selectedSubmissionId={resolvedSubmissionId}
         onSubmissionChange={setSelectedSubmissionId}
         history={history}
-        historyLoading={historyLoading}
         onItemTeamsChanged={onItemTeamsChanged}
       />
       <DashboardGrid

--- a/src/app/components/dashboard/types.ts
+++ b/src/app/components/dashboard/types.ts
@@ -1,20 +1,3 @@
-export interface InspectionDataSummary {
-  overallStatus: 'compliant' | 'non-compliant' | 'needs-attention'
-  checklistItems: Array<{
-    section?: string
-    description: string
-    status: 'pass' | 'fail' | 'na'
-    notes: string
-  }>
-  correctiveActions: Array<{
-    description: string
-    dueDate: string
-    completed: boolean
-  }>
-  facilityName: string | null
-  inspectionDate: string | null
-}
-
 export interface ChecklistTotals {
   pass: number
   fail: number

--- a/src/app/components/dashboard/useDashboardStats.ts
+++ b/src/app/components/dashboard/useDashboardStats.ts
@@ -1,11 +1,7 @@
 import { useMemo } from 'react'
 import type { HistoryItem } from '../history/HistorySidebar'
-import type {
-  DashboardStats,
-  FlaggedForm,
-  InspectionDataSummary,
-  MonthBucket,
-} from './types'
+import type { InspectionData } from '@/lib/types/inspection'
+import type { DashboardStats, FlaggedForm, MonthBucket } from './types'
 
 function monthKey(d: Date) {
   return `${d.getFullYear()}-${d.getMonth()}`
@@ -22,7 +18,7 @@ export function useDashboardStats(history: HistoryItem[]): DashboardStats {
     // Compliance across the (already-filtered) history
     const compliant = history.filter(
       (item) =>
-        (item.data as Partial<InspectionDataSummary>).overallStatus === 'compliant',
+        (item.data as Partial<InspectionData>).overallStatus === 'compliant',
     ).length
     const compliancePercent =
       history.length === 0 ? 100 : Math.round((compliant / history.length) * 100)
@@ -30,7 +26,7 @@ export function useDashboardStats(history: HistoryItem[]): DashboardStats {
     // BMP totals across all history
     const checklistTotals = { pass: 0, fail: 0, na: 0 }
     for (const item of history) {
-      for (const bmp of (item.data as Partial<InspectionDataSummary>)
+      for (const bmp of (item.data as Partial<InspectionData>)
         .checklistItems ?? []) {
         if (bmp.status === 'pass') checklistTotals.pass++
         else if (bmp.status === 'fail') checklistTotals.fail++
@@ -50,12 +46,12 @@ export function useDashboardStats(history: HistoryItem[]): DashboardStats {
       })
     }
     for (const item of history) {
-      const d = item.data as Partial<InspectionDataSummary>
+      const d = item.data as Partial<InspectionData>
       const dateStr = d.inspectionDate
       const key = monthKey(dateStr ? new Date(dateStr) : new Date(item.processedAt))
       const bucket = bucketMap.get(key)
       if (!bucket) continue
-      const status = (item.data as Partial<InspectionDataSummary>).overallStatus
+      const status = (item.data as Partial<InspectionData>).overallStatus
       if (status === 'compliant') bucket.compliant++
       else if (status === 'non-compliant') bucket.nonCompliant++
       else bucket.needsAttention++
@@ -64,7 +60,7 @@ export function useDashboardStats(history: HistoryItem[]): DashboardStats {
 
     // Open corrective actions (documented) + BMP failures with no documented action (gaps)
     const openActions = history.flatMap((item) => {
-      const d = item.data as Partial<InspectionDataSummary>
+      const d = item.data as Partial<InspectionData>
       const documented = (d.correctiveActions ?? [])
         .filter((a) => !a.completed)
         .map((a) => ({
@@ -95,11 +91,11 @@ export function useDashboardStats(history: HistoryItem[]): DashboardStats {
     const flaggedForms: FlaggedForm[] = history
       .filter(
         (item) =>
-          (item.data as Partial<InspectionDataSummary>).overallStatus ===
+          (item.data as Partial<InspectionData>).overallStatus ===
           'non-compliant',
       )
       .map((item) => {
-        const d = item.data as Partial<InspectionDataSummary>
+        const d = item.data as Partial<InspectionData>
         return {
           submissionId: item.id,
           facilityName: item?.facilityName ?? 'unknown',

--- a/src/app/components/dashboard/useDashboardStats.ts
+++ b/src/app/components/dashboard/useDashboardStats.ts
@@ -17,8 +17,7 @@ export function useDashboardStats(history: HistoryItem[]): DashboardStats {
 
     // Compliance across the (already-filtered) history
     const compliant = history.filter(
-      (item) =>
-        (item.data as Partial<InspectionData>).overallStatus === 'compliant',
+      (item) => (item.data as Partial<InspectionData>).overallStatus === 'compliant',
     ).length
     const compliancePercent =
       history.length === 0 ? 100 : Math.round((compliant / history.length) * 100)
@@ -26,8 +25,7 @@ export function useDashboardStats(history: HistoryItem[]): DashboardStats {
     // BMP totals across all history
     const checklistTotals = { pass: 0, fail: 0, na: 0 }
     for (const item of history) {
-      for (const bmp of (item.data as Partial<InspectionData>)
-        .checklistItems ?? []) {
+      for (const bmp of (item.data as Partial<InspectionData>).checklistItems ?? []) {
         if (bmp.status === 'pass') checklistTotals.pass++
         else if (bmp.status === 'fail') checklistTotals.fail++
         else checklistTotals.na++
@@ -91,8 +89,7 @@ export function useDashboardStats(history: HistoryItem[]): DashboardStats {
     const flaggedForms: FlaggedForm[] = history
       .filter(
         (item) =>
-          (item.data as Partial<InspectionData>).overallStatus ===
-          'non-compliant',
+          (item.data as Partial<InspectionData>).overallStatus === 'non-compliant',
       )
       .map((item) => {
         const d = item.data as Partial<InspectionData>

--- a/src/app/components/form_submission/EditMetaBadge.tsx
+++ b/src/app/components/form_submission/EditMetaBadge.tsx
@@ -2,22 +2,10 @@ import Box from '@mui/material/Box'
 import Chip from '@mui/material/Chip'
 import Typography from '@mui/material/Typography'
 import type { EditMeta } from '@/lib/types/inspection'
+import { formatTime } from '@/lib/dateUtils'
 
 interface Props {
   meta: EditMeta
-}
-
-function formatTime(iso: string): string {
-  try {
-    return new Intl.DateTimeFormat(undefined, {
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    }).format(new Date(iso))
-  } catch {
-    return iso
-  }
 }
 
 export default function EditMetaBadge({ meta }: Props) {

--- a/src/app/components/form_submission/InspectionResults.tsx
+++ b/src/app/components/form_submission/InspectionResults.tsx
@@ -716,9 +716,9 @@ export default function InspectionResults({ data, currentUserName, onEdit }: Pro
               <Table size="small">
                 <TableHead>
                   <TableRow>
-                    <TableCell sx={{ fontWeight: 600 }}>Description</TableCell>
-                    <TableCell sx={{ fontWeight: 600, width: 90 }}>Status</TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>Notes</TableCell>
+                    <TableCell>Description</TableCell>
+                    <TableCell sx={{ width: 90 }}>Status</TableCell>
+                    <TableCell>Notes</TableCell>
                     {canEdit && <TableCell sx={{ width: 40 }} />}
                   </TableRow>
                 </TableHead>

--- a/src/app/components/form_submission/InspectionResults.tsx
+++ b/src/app/components/form_submission/InspectionResults.tsx
@@ -54,7 +54,6 @@ const bmpChipProps: Record<
   na: { label: 'N/A', color: 'default' },
 }
 
-// ── Edit type chip selector ────────────────────────────────────────────────────
 function EditTypeSelector({
   value,
   onChange,
@@ -86,7 +85,6 @@ function EditTypeSelector({
   )
 }
 
-// ── Section heading ────────────────────────────────────────────────────────────
 function SectionHeading({
   children,
   large,
@@ -111,7 +109,6 @@ function SectionHeading({
   )
 }
 
-// ── Facility field ─────────────────────────────────────────────────────────────
 function FacilityField({
   label,
   fieldKey,
@@ -217,7 +214,6 @@ function FacilityField({
   )
 }
 
-// ── Main component ─────────────────────────────────────────────────────────────
 export default function InspectionResults({ data, currentUserName, onEdit }: Props) {
   const canEdit = !!onEdit
 
@@ -248,7 +244,6 @@ export default function InspectionResults({ data, currentUserName, onEdit }: Pro
     }
   }
 
-  // ── Facility field save ──────────────────────────────────────────────────────
   function saveFacilityField(fieldKey: string, newValue: string, meta: EditMeta) {
     if (!onEdit) return
     onEdit({
@@ -261,7 +256,6 @@ export default function InspectionResults({ data, currentUserName, onEdit }: Pro
     })
   }
 
-  // ── Checklist item edit ──────────────────────────────────────────────────────
   function ChecklistEditRow({ index }: { index: number }) {
     const item = bmpItems[index]
     const [desc, setDesc] = useState(item.description)
@@ -346,7 +340,6 @@ export default function InspectionResults({ data, currentUserName, onEdit }: Pro
     )
   }
 
-  // ── New checklist item ───────────────────────────────────────────────────────
   function NewChecklistItemForm() {
     const [desc, setDesc] = useState('')
     const [status, setStatus] = useState<ChecklistStatus>('pass')
@@ -432,7 +425,6 @@ export default function InspectionResults({ data, currentUserName, onEdit }: Pro
     )
   }
 
-  // ── New corrective action ────────────────────────────────────────────────────
   function NewActionForm() {
     const [desc, setDesc] = useState('')
     const [dueDate, setDueDate] = useState('')
@@ -512,7 +504,6 @@ export default function InspectionResults({ data, currentUserName, onEdit }: Pro
     )
   }
 
-  // ── Corrective action edit ───────────────────────────────────────────────────
   function ActionEditRow({ index }: { index: number }) {
     const action = correctiveActions[index]
     const [desc, setDesc] = useState(action.description)

--- a/src/app/components/main/UserMenu.tsx
+++ b/src/app/components/main/UserMenu.tsx
@@ -126,8 +126,6 @@ export default function UserMenu() {
                 '& .MuiToggleButton-root': {
                   px: 1.25,
                   py: 0.25,
-                  fontWeight: 600,
-                  textTransform: 'none',
                   lineHeight: 1.6,
                 },
               }}

--- a/src/app/components/upload/UploadFlowDialog.tsx
+++ b/src/app/components/upload/UploadFlowDialog.tsx
@@ -229,12 +229,6 @@ export default function UploadFlowDialog({ open, file, onClose, onSaved }: Props
               gap: 2,
             }}
           >
-            {/* <Box
-              component="img"
-              src="/visua_mascot.png"
-              alt="FormVis mascot"
-              sx={{ width: 110, height: 110, objectFit: 'contain' }}
-            /> */}
             {processed ? (
               <>
                 <CheckCircleIcon sx={{ color: 'success.main', fontSize: 36 }} />

--- a/src/app/forms/[id]/page.tsx
+++ b/src/app/forms/[id]/page.tsx
@@ -26,9 +26,10 @@ import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
 import HistoryIcon from '@mui/icons-material/History'
 import Link from 'next/link'
 import { gqlFetch } from '@/lib/graphql/client'
+import { submissionToHistoryItem } from '@/app/submissionUtils'
 import InspectionResults from '@/app/components/form_submission/InspectionResults'
 import type { InspectionData } from '@/lib/types/inspection'
-import HistorySidebar from '@/app/components/history/HistorySidebar'
+import HistorySidebar, { type HistoryItem } from '@/app/components/history/HistorySidebar'
 import PdfSection from '@/app/components/pdf/PdfSection'
 import UserMenu from '@/app/components/main/UserMenu'
 import DeleteFormButton from './DeleteFormButton'
@@ -75,17 +76,6 @@ const UPDATE_DATA_MUTATION = `
   }
 `
 
-function submissionToHistoryItem(s: GqlSubmission) {
-  return {
-    id: s.id,
-    processedAt: s.processedAt,
-    permitNumber: (s.data?.permitNumber as string | undefined) ?? '',
-    facilityName:
-      (s.data?.facilityName as string | undefined) ?? s.displayName ?? null,
-    data: s.data,
-    teams: s.teams,
-  }
-}
 
 function breadcrumbTitle(submission: GqlSubmission | null, loading: boolean): string {
   if (loading) return '…'
@@ -104,9 +94,7 @@ export default function FormDetailPage() {
   const [loading, setLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
   const [sidebarOpen, setSidebarOpen] = useState(false)
-  const [history, setHistory] = useState<
-    ReturnType<typeof submissionToHistoryItem>[]
-  >([])
+  const [history, setHistory] = useState<HistoryItem[]>([])
   const [ncModalOpen, setNcModalOpen] = useState(false)
   const [currentUserName, setCurrentUserName] = useState<string | undefined>(
     undefined,

--- a/src/app/forms/[id]/page.tsx
+++ b/src/app/forms/[id]/page.tsx
@@ -29,7 +29,9 @@ import { gqlFetch } from '@/lib/graphql/client'
 import { submissionToHistoryItem } from '@/app/submissionUtils'
 import InspectionResults from '@/app/components/form_submission/InspectionResults'
 import type { InspectionData } from '@/lib/types/inspection'
-import HistorySidebar, { type HistoryItem } from '@/app/components/history/HistorySidebar'
+import HistorySidebar, {
+  type HistoryItem,
+} from '@/app/components/history/HistorySidebar'
 import PdfSection from '@/app/components/pdf/PdfSection'
 import UserMenu from '@/app/components/main/UserMenu'
 import DeleteFormButton from './DeleteFormButton'
@@ -75,7 +77,6 @@ const UPDATE_DATA_MUTATION = `
     updateSubmissionData(id: $id, data: $data) { id data }
   }
 `
-
 
 function breadcrumbTitle(submission: GqlSubmission | null, loading: boolean): string {
   if (loading) return '…'

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,0 @@
-html,
-body {
-  overflow-x: hidden;
-}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import Toolbar from '@mui/material/Toolbar'
 import Typography from '@mui/material/Typography'
 import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined'
 import { gqlFetch } from '@/lib/graphql/client'
+import { submissionToHistoryItem } from './submissionUtils'
 import { type HistoryItem } from './components/history/HistorySidebar'
 import UserMenu from './components/main/UserMenu'
 import UploaderCard from './components/dashboard/UploaderCard'
@@ -32,17 +33,6 @@ interface GqlSubmission {
   teams: Array<{ id: string; name: string }>
 }
 
-function submissionToHistoryItem(s: GqlSubmission): HistoryItem {
-  return {
-    id: s.id,
-    processedAt: s.processedAt,
-    permitNumber: (s.data?.permitNumber as string | undefined) ?? '',
-    facilityName:
-      (s.data?.facilityName as string | undefined) ?? s.displayName ?? null,
-    data: s.data,
-    teams: s.teams,
-  }
-}
 
 export default function Home() {
   const router = useRouter()

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,6 @@ interface GqlSubmission {
   teams: Array<{ id: string; name: string }>
 }
 
-
 export default function Home() {
   const router = useRouter()
   const [dialogFile, setDialogFile] = useState<File | null>(null)

--- a/src/app/settings/components/AddMemberDialog.tsx
+++ b/src/app/settings/components/AddMemberDialog.tsx
@@ -24,8 +24,6 @@ import SearchIcon from '@mui/icons-material/Search'
 import { gqlFetch } from '@/lib/graphql/client'
 import { GqlTeamMember, GqlUser, UserAvatar } from './TeamCard'
 
-// ── GraphQL fragments ─────────────────────────────────────────────────────────
-
 const SEARCH_USERS_QUERY = `
   query SearchUsers($query: String!) {
     searchUsers(query: $query) {
@@ -41,8 +39,6 @@ const ADD_MEMBER_MUTATION = `
     }
   }
 `
-
-// ── Add member dialog ─────────────────────────────────────────────────────────
 
 interface AddMemberDialogProps {
   teamId: string

--- a/src/app/settings/components/TeamCard.tsx
+++ b/src/app/settings/components/TeamCard.tsx
@@ -33,8 +33,6 @@ import InputBase from '@mui/material/InputBase'
 import { gqlFetch } from '@/lib/graphql/client'
 import { AddMemberDialog } from './AddMemberDialog'
 
-// ── GraphQL fragments ─────────────────────────────────────────────────────────
-
 const RENAME_TEAM_MUTATION = `
   mutation RenameTeam($id: ID!, $name: String!) {
     renameTeam(id: $id, name: $name) { id name }
@@ -61,8 +59,6 @@ const CHANGE_ROLE_MUTATION = `
   }
 `
 
-// ── Types ─────────────────────────────────────────────────────────────────────
-
 export interface GqlUser {
   id: string
   name: string | null
@@ -82,8 +78,6 @@ export interface GqlTeam {
   name: string
   members: GqlTeamMember[]
 }
-
-// ── Sub-components ────────────────────────────────────────────────────────────
 
 export function UserAvatar({ user, size = 32 }: { user: GqlUser; size?: number }) {
   return (
@@ -109,8 +103,6 @@ function RoleChip({ role }: { role: string }) {
     />
   )
 }
-
-// ── Team card ─────────────────────────────────────────────────────────────────
 
 interface TeamCardProps {
   team: GqlTeam

--- a/src/app/settings/components/TeamManager.tsx
+++ b/src/app/settings/components/TeamManager.tsx
@@ -13,8 +13,6 @@ import Link from 'next/link'
 import { gqlFetch } from '@/lib/graphql/client'
 import { GqlTeam, GqlTeamMember, TeamCard } from './TeamCard'
 
-// ── GraphQL fragments ─────────────────────────────────────────────────────────
-
 const TEAMS_QUERY = `
   query {
     teams {
@@ -38,8 +36,6 @@ const CREATE_TEAM_MUTATION = `
     }
   }
 `
-
-// ── Main component ────────────────────────────────────────────────────────────
 
 export default function TeamManager() {
   const [teams, setTeams] = useState<GqlTeam[]>([])

--- a/src/app/settings/users/components/UserManagementList.tsx
+++ b/src/app/settings/users/components/UserManagementList.tsx
@@ -24,8 +24,6 @@ import { UserRow } from './UserRow'
 import { AddUserToTeamDialog } from './AddUserToTeamDialog'
 import { DeleteUserDialog } from './DeleteUserDialog'
 
-// ── Component ─────────────────────────────────────────────────────────────────
-
 export default function UserManagementList() {
   const [authorized, setAuthorized] = useState<boolean | null>(null)
   const [currentUserId, setCurrentUserId] = useState<string | null>(null)
@@ -71,8 +69,6 @@ export default function UserManagementList() {
         setLoading(false)
       })
   }, [])
-
-  // ── Actions ───────────────────────────────────────────────────────────────
 
   async function handleToggleAdmin(user: AdminUser) {
     setBusyUserIds((prev) => new Set(prev).add(user.id))
@@ -182,8 +178,6 @@ export default function UserManagementList() {
     }
   }
 
-  // ── Render guards ─────────────────────────────────────────────────────────
-
   if (loading || authorized === null) {
     return (
       <Container
@@ -205,8 +199,6 @@ export default function UserManagementList() {
     )
   }
 
-  // ── Filtered list ─────────────────────────────────────────────────────────
-
   const filtered = users.filter((u) => {
     if (!search) return true
     const q = search.toLowerCase()
@@ -215,8 +207,6 @@ export default function UserManagementList() {
 
   const deleteUser = users.find((u) => u.id === deleteUserId)
   const addUserToTeamUser = users.find((u) => u.id === addTeamUserId)
-
-  // ── Main UI ───────────────────────────────────────────────────────────────
 
   return (
     <Container maxWidth="md" sx={{ py: 4 }}>
@@ -283,7 +273,6 @@ export default function UserManagementList() {
         />
       ))}
 
-      {/* ── Dialogs ── */}
       {addUserToTeamUser && (
         <AddUserToTeamDialog
           user={addUserToTeamUser}

--- a/src/app/settings/users/components/graphql.ts
+++ b/src/app/settings/users/components/graphql.ts
@@ -1,5 +1,3 @@
-// ── GraphQL ───────────────────────────────────────────────────────────────────
-
 export const ME_QUERY = `query { me { id isAdmin } }`
 
 export const ADMIN_USER_LIST_QUERY = `
@@ -41,8 +39,6 @@ export const REMOVE_USER_FROM_TEAM_MUTATION = `
   }
 `
 
-// ── Types ─────────────────────────────────────────────────────────────────────
-
 export interface UserTeamMembership {
   teamId: string
   teamName: string
@@ -63,8 +59,6 @@ export interface SlimTeam {
   id: string
   name: string
 }
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
 
 export function userInitials(user: AdminUser): string {
   if (user.name)

--- a/src/app/submissionUtils.test.ts
+++ b/src/app/submissionUtils.test.ts
@@ -1,0 +1,29 @@
+import { submissionToHistoryItem, type SubmissionForHistory } from './submissionUtils'
+
+const base: SubmissionForHistory = {
+  id: 'abc-123',
+  processedAt: '2024-06-15T12:00:00.000Z',
+  displayName: 'Acme Site',
+  data: {},
+  teams: [],
+}
+
+describe('submissionToHistoryItem', () => {
+  it('prefers facilityName from data over displayName', () => {
+    const s = { ...base, data: { facilityName: 'Data Facility' } }
+    expect(submissionToHistoryItem(s).facilityName).toBe('Data Facility')
+  })
+
+  it('falls back to displayName when facilityName absent from data', () => {
+    expect(submissionToHistoryItem(base).facilityName).toBe('Acme Site')
+  })
+
+  it('returns null when neither facilityName nor displayName available', () => {
+    const s = { ...base, displayName: null }
+    expect(submissionToHistoryItem(s).facilityName).toBeNull()
+  })
+
+  it('falls back to empty string when permitNumber absent', () => {
+    expect(submissionToHistoryItem(base).permitNumber).toBe('')
+  })
+})

--- a/src/app/submissionUtils.ts
+++ b/src/app/submissionUtils.ts
@@ -1,0 +1,21 @@
+import type { HistoryItem } from './components/history/HistorySidebar'
+
+export interface SubmissionForHistory {
+  id: string
+  processedAt: string
+  displayName: string | null
+  data: Record<string, unknown>
+  teams: Array<{ id: string; name: string }>
+}
+
+export function submissionToHistoryItem(s: SubmissionForHistory): HistoryItem {
+  return {
+    id: s.id,
+    processedAt: s.processedAt,
+    permitNumber: (s.data?.permitNumber as string | undefined) ?? '',
+    facilityName:
+      (s.data?.facilityName as string | undefined) ?? s.displayName ?? null,
+    data: s.data,
+    teams: s.teams,
+  }
+}

--- a/src/app/theme.ts
+++ b/src/app/theme.ts
@@ -61,6 +61,20 @@ export function makeTheme(mode: ThemeMode) {
           outlined: { borderColor: dark ? '#2D3548' : '#E5E8EC' },
         },
       },
+      MuiToggleButton: {
+        styleOverrides: {
+          root: {
+            textTransform: 'none',
+            fontWeight: 600,
+          },
+        },
+      },
+      MuiCssBaseline: {
+        styleOverrides: {
+          html: { overflowX: 'hidden' },
+          body: { overflowX: 'hidden' },
+        },
+      },
       MuiTableCell: {
         styleOverrides: {
           head: {

--- a/src/lib/dateUtils.test.ts
+++ b/src/lib/dateUtils.test.ts
@@ -1,0 +1,28 @@
+import { isOverdue, formatTime } from './dateUtils'
+
+describe('isOverdue', () => {
+  it('returns true for a past date', () => {
+    expect(isOverdue('2000-01-01')).toBe(true)
+  })
+
+  it('returns false for a future date', () => {
+    const future = new Date(Date.now() + 86_400_000).toISOString()
+    expect(isOverdue(future)).toBe(false)
+  })
+
+  it('returns false for an empty string', () => {
+    expect(isOverdue('')).toBe(false)
+  })
+})
+
+describe('formatTime', () => {
+  it('formats a valid ISO string', () => {
+    const result = formatTime('2024-06-15T14:30:00.000Z')
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  it('returns the original string when parsing fails', () => {
+    expect(formatTime('not-a-date')).toBe('not-a-date')
+  })
+})

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,16 @@
+export function isOverdue(dueDate: string): boolean {
+  return !!dueDate && new Date(dueDate) < new Date()
+}
+
+export function formatTime(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(iso))
+  } catch {
+    return iso
+  }
+}

--- a/src/lib/graphql/builder.ts
+++ b/src/lib/graphql/builder.ts
@@ -4,9 +4,6 @@ import { auth } from '@/auth'
 import { db, type Db } from '@/lib/db'
 import { users } from '../../../db/schema'
 
-// ── Context ──────────────────────────────────────────────────────────────────
-// Built once per request in the Yoga context factory
-// userId comes from the NextAuth session; null if unauthenticated
 export interface Context {
   db: Db
   userId: string | null
@@ -30,8 +27,6 @@ export async function buildContext(): Promise<Context> {
   return { db, userId, isAdmin }
 }
 
-// ── Builder ───────────────────────────────────────────────────────────────────
-// Single shared instance — all schema files import from here
 export const builder = new SchemaBuilder<{
   Context: Context
   Scalars: {

--- a/src/lib/graphql/mutations.ts
+++ b/src/lib/graphql/mutations.ts
@@ -19,7 +19,6 @@ import {
   UserSettingsRef,
 } from './types'
 
-// ── Input types ───────────────────────────────────────────────────────────────
 const CreateSubmissionInput = builder.inputType('CreateSubmissionInput', {
   fields: (t) => ({
     fileName: t.string({ required: true }),
@@ -48,7 +47,6 @@ const UpdateSettingsInput = builder.inputType('UpdateSettingsInput', {
   }),
 })
 
-// ── Mutations ─────────────────────────────────────────────────────────────────
 builder.mutationType({
   fields: (t) => ({
     // Save a processed form submission (called after extraction)

--- a/src/lib/graphql/queries.ts
+++ b/src/lib/graphql/queries.ts
@@ -18,7 +18,6 @@ import {
   UserSettingsRef,
 } from './types'
 
-// ── Queries ───────────────────────────────────────────────────────────────────
 builder.queryType({
   fields: (t) => ({
     // Current authenticated user

--- a/src/lib/graphql/schema.ts
+++ b/src/lib/graphql/schema.ts
@@ -3,5 +3,4 @@ import './mutations'
 import './queries'
 import './types'
 
-// ── Export ────────────────────────────────────────────────────────────────────
 export const schema = builder.toSchema()

--- a/src/lib/graphql/types.ts
+++ b/src/lib/graphql/types.ts
@@ -12,7 +12,6 @@ import {
 } from '../../../db/schema'
 import { builder } from './builder'
 
-// ── Object types ──────────────────────────────────────────────────────────────
 export interface UserTeamMembership {
   teamId: string
   teamName: string


### PR DESCRIPTION
closes #31

cleaning up the codebase a bit more

- separate out helper functions into utils files
  - add some unit tests to start
- clean up types
- favor use of default theme & theme config rather than inline style adjustments
- deletes some redundant comments and unused code